### PR TITLE
docs: specify build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ The Dash SDK works using multiple dependencies that might interest you:
 
 Some features might be more extensive in those libs, as Dash SDK only wraps around them to provide a single interface that is easy to use (and thus has less features).
 
+### Build : 
+
+To build the Dash SDK, you will need to have TypeScript installed.  
+In addition, for REPL Execution, ts-node will also be required. 
+
+```shell script
+npm install -g typescript ts-node
+```
+
 ## Documentation
 
 More extensive documentation available at https://dashevo.github.io/DashJS/.

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,15 @@ client.getWalletAccount().then(async (account) => {
 });
 ```
 
+### Build : 
+
+To build the Dash SDK, you will need to have TypeScript installed.  
+In addition, for REPL Execution, ts-node will also be required. 
+
+```shell script
+npm install -g typescript ts-node
+```
+
 
 ### Use-cases examples
 - [Generate a mnemonic](/examples/generate-a-new-mnemonic.md) 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -7,6 +7,9 @@ Having [NodeJS](https://nodejs.org/) installed, just type :
 ```bash
 npm install dash
 ```
+
+Or for browsers : `<script src="https://unpkg.com/dash"></script>`   
+
 ## Initialization
 
 Let's create a Dash SDK client instance specifying both our mnemonic and the schema we wish to work with.

--- a/docs/getting-started/with-typescript.md
+++ b/docs/getting-started/with-typescript.md
@@ -1,6 +1,9 @@
-In order to use Dash SDK with TypeScript.    
+In order to use Dash SDK with TypeScript, you will need some dependencies to be manually installed.   
 
-Create an index.ts file  
+`npm install -g typescript` - Required for compilation (`tsc`).    
+`npm install -g ts-node` - Required for REPL / Execution.     
+
+Create a new file, let's assume you will name it `myScript.ts`.    
 
 ```js
 import Dash from 'dash';
@@ -27,5 +30,6 @@ Have a following `tsconfig.json` file
 }
 ```
 
+**Run without compiling**: `ts-node myCode.ts`  
 **Compile:** `tsc -p tsconfig.json`  
-**Run:** `node index.js`  
+**Run:** `node myCode.js`  


### PR DESCRIPTION
## Issue being fixed or feature implemented

In order to guide developers that want to build, compile or run locally directly in typescript, we specified the dependencies that are needed (typescript / ts-node) into the documentation.

## What was done?
- updated `getting-started/quickstart`, `getting-started/with-typescript`, `docs/README` and the root Readme. 

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
