### PR TITLE
build(tsconfig): specify inclusions instead of exclusions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "declaration": true,
     "declarationDir": "./dist"
   },
-  "exclude": ["node_modules", "examples", "build", "dist"],
+  "include": ["src"],
   "typeRoots": ["node_modules/@types"]
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

When working into the dash-sdk repository (for instance, when working with tsdoc), the tsconfig file would try to compile it (as we used `excludes` folder) which would fail the compilation. 
In order to fix that behavior and prevent further issues, and because we actually only compile contents of `/src`, we need to replace exclusions for inclusions. 
This is what this PR do. 

## What was done?
- tsconfig: specify inclusion instead of exclusion

## How Has This Been Tested?
Tested compilation & browsers unit test works as expected.

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
