### PR TITLE
feat: convert string identifiers in `where` conditions

### DIFF
--- a/src/SDK/Client/Platform/methods/documents/get.spec.ts
+++ b/src/SDK/Client/Platform/methods/documents/get.spec.ts
@@ -47,7 +47,7 @@ describe('Client - Platform - Documents - .get()', () => {
       ],
     });
 
-    expect(getDocumentsMock).to.have.been.calledOnceWithExactly(
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
       appDefinition.contractId,
       'withByteArrays',
       {
@@ -55,7 +55,7 @@ describe('Client - Platform - Documents - .get()', () => {
           ['identifierField', '==', id],
         ],
       },
-    );
+    ]);
   });
 
   it('should convert nested identifier properties inside where condition if `elementMatch` is used', async () => {
@@ -102,15 +102,15 @@ describe('Client - Platform - Documents - .get()', () => {
       ],
     });
 
-    expect(getDocumentsMock).to.have.been.calledOnceWithExactly(
-        appDefinition.contractId,
-        'withByteArrays',
-        {
-          where: [
-            ['nestedObject', 'elementMatch', ['idField', '==', id]],
-            ['nestedObject', 'elementMatch', ['anotherNested', 'elementMatch', ['anotherIdField', '==', id]]]
-          ],
-        },
-    );
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        where: [
+          ['nestedObject', 'elementMatch', ['idField', '==', id]],
+          ['nestedObject', 'elementMatch', ['anotherNested', 'elementMatch', ['anotherIdField', '==', id]]]
+        ],
+      },
+    ]);
   });
 });

--- a/src/SDK/Client/Platform/methods/documents/get.spec.ts
+++ b/src/SDK/Client/Platform/methods/documents/get.spec.ts
@@ -1,0 +1,116 @@
+import getDataContractFixture from '@dashevo/dpp/lib/test/fixtures/getDataContractFixture';
+import generateRandomIdentifier from '@dashevo/dpp/lib/test/utils/generateRandomIdentifier';
+import createDPPMock from '@dashevo/dpp/lib/test/mocks/createDPPMock';
+
+import get from './get';
+import { expect } from 'chai';
+
+describe('Client - Platform - Documents - .get()', () => {
+  let platform;
+  let dataContract;
+  let appDefinition;
+  let getDocumentsMock;
+  let appsGetMock;
+
+  beforeEach(function beforeEach() {
+    dataContract = getDataContractFixture();
+
+    appDefinition = {
+      contractId: dataContract.getId(),
+      contract: dataContract,
+    };
+
+    getDocumentsMock = this.sinon.stub().resolves([]);
+    appsGetMock = this.sinon.stub().returns(appDefinition);
+
+    platform = {
+      dpp: createDPPMock(this.sinon),
+      client: {
+        getApps: () => ({
+          has: this.sinon.stub().returns(true),
+          get: appsGetMock,
+        }),
+        getDAPIClient: () => ({
+          platform: {
+            getDocuments: getDocumentsMock,
+          },
+        })
+      },
+    };
+  });
+
+  it('should convert identifier properties inside where condition', async () => {
+    const id = generateRandomIdentifier();
+    await get.call(platform, 'app.withByteArrays', {
+      where: [
+        ['identifierField', '==', id.toString()],
+      ],
+    });
+
+    expect(getDocumentsMock).to.have.been.calledOnceWithExactly(
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        where: [
+          ['identifierField', '==', id],
+        ],
+      },
+    );
+  });
+
+  it('should convert nested identifier properties inside where condition if `elementMatch` is used', async () => {
+    const id = generateRandomIdentifier();
+
+    dataContract = getDataContractFixture();
+    dataContract.documents.withByteArrays.properties.nestedObject = {
+      type: 'object',
+      properties: {
+        idField: {
+          type: "array",
+          byteArray: true,
+          contentMediaType: "application/x.dash.dpp.identifier",
+          minItems: 32,
+          maxItems: 32,
+        },
+        anotherNested: {
+          type: 'object',
+          properties: {
+            anotherIdField: {
+              type: "array",
+              byteArray: true,
+              contentMediaType: "application/x.dash.dpp.identifier",
+              minItems: 32,
+              maxItems: 32,
+            },
+          },
+        },
+      },
+    };
+
+    appDefinition = {
+      contractId: dataContract.getId(),
+      contract: dataContract,
+    };
+
+    appsGetMock.reset();
+    appsGetMock.returns(appDefinition);
+
+    await get.call(platform, 'app.withByteArrays', {
+      where: [
+        ['nestedObject', 'elementMatch', ['idField', '==', id.toString()]],
+        ['nestedObject', 'elementMatch', ['anotherNested', 'elementMatch', ['anotherIdField', '==', id.toString()]]]
+      ],
+    });
+
+    expect(getDocumentsMock).to.have.been.calledOnceWithExactly(
+        appDefinition.contractId,
+        'withByteArrays',
+        {
+          where: [
+            ['nestedObject', 'elementMatch', ['idField', '==', id]],
+            ['nestedObject', 'elementMatch', ['anotherNested', 'elementMatch', ['anotherIdField', '==', id]]]
+          ],
+        },
+    );
+  });
+});

--- a/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/src/SDK/Client/Platform/methods/documents/get.ts
@@ -59,6 +59,33 @@ export async function get(this: Platform, typeLocator: string, opts: fetchOpts):
     // If not present, will fetch contract based on appName and contractId store in this.apps.
     await ensureAppContractFetched.call(this, appName);
 
+    if (opts.where) {
+        const binaryProperties = appDefinition.contract.getBinaryProperties(fieldType);
+
+        opts.where.forEach(([propertyName, operator, propertyValue], index) => {
+            if (operator === 'elementMatch') {
+
+            }
+
+            const property = binaryProperties[propertyName];
+
+            if (property && property.contentMediaType === Identifier.MEDIA_TYPE) {
+                if (typeof value === 'string') {
+                    try {
+                        opts.where[index][2] = Identifier.from(propertyValue);
+                    } catch (e) {
+                        if (!(e instanceof IdentifierError)) {
+                            throw e;
+                        }
+                    }
+                }
+            }
+
+            return []
+        });
+    }
+
+
     // @ts-ignore
     const rawDocuments = await this.client.getDAPIClient().platform.getDocuments(
         appDefinition.contractId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For search for `Documents` to work we need to submit identifiers in `where` condition as `Buffers`

## What was done?
<!--- Describe your changes in detail -->
- Modified `douments.get` method
- Implemented tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
