### PR TITLE
fix: `$id` and `$ownerId` are not converted to identifiers

### DIFF
--- a/src/SDK/Client/Platform/methods/documents/get.spec.ts
+++ b/src/SDK/Client/Platform/methods/documents/get.spec.ts
@@ -58,6 +58,29 @@ describe('Client - Platform - Documents - .get()', () => {
     ]);
   });
 
+  it('should convert $id and $ownerId to identifiers inside where condition', async () => {
+    const id = generateRandomIdentifier();
+    const ownerId = generateRandomIdentifier();
+
+    await get.call(platform, 'app.withByteArrays', {
+      where: [
+        ['$id', '==', id.toString()],
+        ['$ownerId', '==', ownerId.toString()],
+      ],
+    });
+
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        where: [
+          ['$id', '==', id],
+          ['$ownerId', '==', ownerId],
+        ],
+      },
+    ]);
+  });
+
   it('should convert nested identifier properties inside where condition if `elementMatch` is used', async () => {
     const id = generateRandomIdentifier();
 

--- a/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/src/SDK/Client/Platform/methods/documents/get.ts
@@ -70,15 +70,18 @@ function convertIdentifierProperties(whereCondition: WhereCondition, binaryPrope
         ];
     }
 
+    let convertedPropertyValue = propertyValue;
+
     const property = binaryProperties[fullPropertyName];
 
-    if (property && property.contentMediaType === Identifier.MEDIA_TYPE) {
-        if (typeof propertyValue === 'string') {
-            return [propertyName, operator, Identifier.from(propertyValue)];
-        }
+    const isPropertyIdentifier = property && property.contentMediaType === Identifier.MEDIA_TYPE;
+    const isSystemIdentifier = ['$id', '$ownerId'].includes(propertyName);
+
+    if (isSystemIdentifier || (isPropertyIdentifier && typeof propertyValue === 'string')) {
+        convertedPropertyValue = Identifier.from(propertyValue);
     }
 
-    return [propertyName, operator, propertyValue];
+    return [propertyName, operator, convertedPropertyValue];
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #145 we supposed to convert identifiers in where conditions from strings to buffers but system properties `$id` and `$ownerId` are not covered.

## What was done?
<!--- Describe your changes in detail -->
Convert system properties `$id` and `$ownerId` from strings to buffers in the `documents.get`'s `where` option. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
