### PR TITLE
feat(ClientApps)!: Client.apps signature is an array app definition

### DIFF
--- a/docs/examples/publishing-a-new-contract.md
+++ b/docs/examples/publishing-a-new-contract.md
@@ -45,11 +45,10 @@ const client = new Dash.Client({
   wallet: {
     mnemonic: "", // Your app mnemonic, which holds the identity
   },
-  apps:{
-    myapp:{
-      contractId:""// The registered contract id    
-    }
-  }
+  apps: [{
+      contractId: "",// The registered contract id 
+      alias: 'myapp'
+  }]
 });
 
 client.isReady().then(getDocuments);

--- a/docs/examples/use-local-evonet.md
+++ b/docs/examples/use-local-evonet.md
@@ -8,11 +8,10 @@ You will then need to pass the seed ip, and [register the DPNS contract](https:/
 const seeds = [{service: '54.245.133.124'}];
 const client = new Dash.Client({
   seeds,
-  apps: {
-    dpns: {
-      contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3'
-    }
-  }
+  apps: [{
+      contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3', 
+      alias: 'dpns'
+    }]
 });
 ```
 

--- a/docs/getting-started/multiple-apps.md
+++ b/docs/getting-started/multiple-apps.md
@@ -7,11 +7,10 @@ You can then pass it as an options.
 
 ```js
 const client = new Dash.Client({
-  apps: {
-    dashpay: {
-      contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3'
-    }
-  }
+  apps: [{
+      contractId: '77w8Xqn25HwJhjodrHW133aXhjuTsTv9ozQaYpSHACE3',
+      alias: 'dashpay'
+  }]
 });
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -15,12 +15,10 @@ Let's create a Dash SDK client instance specifying both our mnemonic and the sch
 const Dash = require("../src");
 const opts = {
   network: 'testnet',
-  apps: {
-    dashpay: {
+  apps: [{
       contractId:1234,
-      schema: require('schema.json')
-    },
-  },
+      contract: require('contract.json')
+  }],
   wallet: {
     mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
   },

--- a/examples/web/usage.web.js
+++ b/examples/web/usage.web.js
@@ -4,11 +4,10 @@ const opts = {
   wallet: {
     mnemonic: "arena light cheap control apple buffalo indicate rare motor valid accident isolate",
   },
-  apps: {
-    dashpay: {
-    contractId: ''// Provide the dashpay contract id here
-    }
-  }
+  apps: [{
+    contractId: '',// Provide the dashpay contract id here
+    alias: 'dashpay'
+  }]
 };
 const clientInstance = new Dash.Client(opts);
 

--- a/src/SDK/Client/Client.ts
+++ b/src/SDK/Client/Client.ts
@@ -3,7 +3,7 @@ import DAPIClientTransport from "@dashevo/wallet-lib/src/transport/DAPIClientTra
 import { Platform } from './Platform';
 import { Network } from "@dashevo/dashcore-lib";
 import DAPIClient from "@dashevo/dapi-client";
-import { ClientApps, ClientAppsOptions } from "./ClientApps";
+import { ClientAppDefinitionOptions, ClientApps } from "./ClientApps";
 
 /**
  * Interface Client Options
@@ -20,7 +20,7 @@ import { ClientApps, ClientAppsOptions } from "./ClientApps";
  * @param {number} [baseBanTime=60000]
  */
 export interface ClientOpts {
-    apps?: ClientAppsOptions,
+    apps?: Array<ClientAppDefinitionOptions>,
     wallet?: Wallet.IWalletOptions,
     walletAccountIndex?: number,
     dapiAddressProvider?: any,
@@ -97,11 +97,16 @@ export class Client {
             this.walletAccountIndex = this.options.walletAccountIndex;
         }
 
-        this.apps = new ClientApps(Object.assign({
-            dpns: {
-                contractId: '3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8'
-            }
-        }, this.options.apps));
+        const appsOpts: Array<ClientAppDefinitionOptions> = [{
+            contractId: '3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8',
+            alias: 'dpns',
+        }];
+
+        if(this.options.apps){
+            appsOpts.push(...this.options.apps);
+        }
+
+        this.apps = new ClientApps(appsOpts)
 
         this.platform = new Platform({
             client: this,

--- a/src/SDK/Client/ClientApps.spec.ts
+++ b/src/SDK/Client/ClientApps.spec.ts
@@ -1,0 +1,86 @@
+import Identifier from "@dashevo/dpp/lib/Identifier";
+import {expect} from 'chai';
+import {ClientApps} from "./ClientApps";
+import 'mocha';
+import exp from "constants";
+
+describe('ClientApps', () => {
+    let apps;
+    it('constructor', function () {
+        apps = new ClientApps();
+        expect(apps.apps).to.deep.equal({});
+
+        const appsFromProps = new ClientApps([{
+            contractId: '3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8',
+            contract: null,
+            aliases: ['dpns']
+        }
+        ]);
+
+        expect(appsFromProps.getApps()).to.deep.equal({
+            "3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8": {
+                contractId: '3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8',
+                contract: null,
+                aliases: ['dpns']
+            }
+        })
+    });
+    it('.set', function () {
+        apps.set('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8', {
+            alias: 'dpns'
+        });
+        expect(apps.getApps()['3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8']).to.deep.equal({
+            "contractId": "3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8",
+            "contract": null,
+            "aliases": ["dpns"],
+        });
+
+        apps.set('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8', {
+            contract: {something: true},
+            aliases: ['tutorialContract', 'contract']
+        });
+        expect(apps.getApps()['3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8']).to.deep.equal({
+            "contractId": "3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8",
+            "contract": {something: true},
+            "aliases": ["dpns", "tutorialContract", "contract"],
+        });
+        expect(apps.getApps()['3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8']).to.deep.equal({
+            "contractId": "3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8",
+            "contract": {something: true},
+            "aliases": ["dpns", "tutorialContract", "contract"],
+        });
+
+    });
+    it('should get', function () {
+        const getByIdentifier = apps.get('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8');
+        expect(getByIdentifier).to.deep.equal({
+            "contractId": "3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8",
+            "contract": {something: true},
+            "aliases": ["dpns", "tutorialContract", "contract"],
+        })
+        const getByAlias = apps.get('tutorialContract');
+        expect(getByAlias).to.deep.equal({
+            "contractId": "3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8",
+            "contract": {something: true},
+            "aliases": ["dpns", "tutorialContract", "contract"],
+        })
+    });
+    it('should .getIdentifiers()', function () {
+        const identifiers = apps.getIdentifiers();
+        expect(identifiers).to.deep.equal([Identifier.from('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8')]);
+    });
+    it('should .getAliases()', function () {
+        const aliases = apps.getAliases();
+        expect(aliases).to.deep.equal(['dpns', 'tutorialContract', 'contract']);
+    });
+    it('should .has', function () {
+        expect(apps.has('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8')).to.equal(true);
+        expect(apps.has(Identifier.from('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u8'))).to.equal(true);
+        expect(apps.has('tutorialContract')).to.equal(true);
+
+        expect(apps.has('3VvS19qomuGSbEYWbTsRzeuRgawU3yK4fPMzLrbV62u9')).to.equal(false);
+        expect(apps.has('tutorialContractt')).to.equal(false);
+    });
+});
+
+

--- a/src/SDK/Client/Platform/methods/contracts/get.ts
+++ b/src/SDK/Client/Platform/methods/contracts/get.ts
@@ -17,13 +17,7 @@ export async function get(this: Platform, identifier: ContractIdentifier): Promi
 
     const contractId : Identifier = Identifier.from(identifier);
 
-    for (const appName of this.client.getApps().getNames()) {
-        const appDefinition = this.client.getApps().get(appName);
-        if (appDefinition.contractId.equals(contractId)) {
-            localContract = appDefinition;
-            break;
-        }
-    }
+    localContract = this.client.getApps().get(contractId);
 
     if (localContract && localContract.contract) {
         return localContract.contract;
@@ -37,18 +31,9 @@ export async function get(this: Platform, identifier: ContractIdentifier): Promi
 
         const contract = await this.dpp.dataContract.createFromBuffer(rawContract);
 
-        if (!localContract) {
-            // If we do not have even the identifier in this.apps, we add it with timestamp as key
-            this.client.getApps().set(
-                Date.now().toString(),
-                {
-                    contractId: contractId,
-                    contract
-                }
-            );
-        } else {
-            localContract.contract = contract;
-        }
+        this.client.getApps().set(contractId, {
+            contract,
+        });
 
         return contract;
     }

--- a/src/SDK/Client/Platform/methods/documents/create.ts
+++ b/src/SDK/Client/Platform/methods/documents/create.ts
@@ -15,7 +15,7 @@ declare interface createOpts {
 export async function create(this: Platform, typeLocator: string, identity: any, data: createOpts = {}): Promise<any> {
     const { dpp } = this;
 
-    const appNames = this.client.getApps().getNames();
+    const appNames = this.client.getApps().getAliases();
 
     //We can either provide of type `dashpay.profile` or if only one schema provided, of type `profile`.
     const [appName, fieldType] = (typeLocator.includes('.')) ? typeLocator.split('.') : [appNames[0], typeLocator];

--- a/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/src/SDK/Client/Platform/methods/documents/get.ts
@@ -120,7 +120,7 @@ export async function get(this: Platform, typeLocator: string, opts: fetchOpts):
 
     // @ts-ignore
     const rawDocuments = await this.client.getDAPIClient().platform.getDocuments(
-        appDefinition.contractId,
+        Identifier.from(appDefinition.contractId),
         fieldType,
         opts
     );

--- a/src/SDK/Client/Platform/methods/names/register.spec.ts
+++ b/src/SDK/Client/Platform/methods/names/register.spec.ts
@@ -19,11 +19,8 @@ describe('Platform', () => {
                 platformMock = {
                     client: {
                         getApps() {
-                            return new ClientApps({
-                                dpns: {
-                                    contractId: generateRandomIdentifier(),
-                                }
-                            });
+                            const appsOps = [{contractId: generateRandomIdentifier(), alias: 'dpns'}];
+                            return new ClientApps(appsOps);
                         }
                     },
                     documents: {

--- a/tests/functional/sdk.js
+++ b/tests/functional/sdk.js
@@ -24,11 +24,10 @@ describe('SDK', function suite() {
       wallet: {
         mnemonic: null,
       },
-      apps: {
-        dpns: {
+      apps: [{
           contractId: dpnsContractId,
-        }
-      }
+          alias: 'dpns'
+        }]
     };
 
     clientInstance = new Dash.Client(clientOpts);


### PR DESCRIPTION
## Issue being fixed or feature implemented

In order to handle some bugs where the same contractID were used with multiple string identifier (we set dpns by default, some users might think they want to add it too under another contract alias, which would not populate appDefinition correctly).

## What was done?
- feat!: SDK Client app now take an array based options
- feat: ClientApps updated to handle multiple alias per app definition.

## How Has This Been Tested?
- Added new ClientApps tests


## Breaking Changes

Instead of doing previously : 

```
new Dash.Client({
 apps: {
   "dashpay": {
        contractId: '',// Provide the dashpay contract id here
   }
 }
});
```

Now : 
```
new Dash.Client({
 apps: [{
    contractId: '',// Provide the dashpay contract id here
    alias: 'dashpay'
  }]
});
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
